### PR TITLE
Output the size of the metadata tags, and add support for detecting APE tags

### DIFF
--- a/mpck/Makefile.am
+++ b/mpck/Makefile.am
@@ -20,6 +20,8 @@ mpck_SOURCES = \
 	frame.h \
 	id3.c \
 	id3.h \
+	ape.c \
+	ape.h \
 	main.c \
 	matrices.h \
 	mp3errors.h \

--- a/mpck/ape.h
+++ b/mpck/ape.h
@@ -19,48 +19,8 @@
  *
  *****************************************************************************
  *
- *   id3.c - functions that do something with id3 tags 
+ *   ape.h - functions that do something with ape tags 
  * 
  */
 
-#include "mpck.h"
-#include "file.h"
-#include "synchsafe.h"
-
-extern int verbose;
-
-/* Skips an id3v1 tag. The first three characters have already been read. */
-int
-skip_id3v1_tag(file)
-	file_info * file;
-{
-	file->id3 |= ID3V1;
-	cfseek(file->fp, 125, SEEK_CUR);
-	return TRUE;
-}
-
-/* Skips an id3v2 tag. The first three characters have already been read. */
-int
-skip_id3v2_tag(file)
-	file_info * file;
-{
-	char buf[8];
-	int res;
-	
-	int version, revision;		/* version of ID3v2 tag 	*/
-	int flags;			/* flags			*/
-	int size;			/* size of tag without header	*/
-
-	res=cfread(buf, 7, file->fp);	/* read rest of header		*/
-	if (res == 0) return FALSE;
-	version  = (int)(buf[0]);
-	revision = (int)(buf[1]);
-	flags    = (int)(buf[2]);
-	size     = INT_SS(buf+3);
-
-	file->id3 |= ID3V2;
-    file->id3v2_size = size;
-	cfseek(file->fp, size, SEEK_CUR);
-	
-	return 0;
-}
+int skip_ape_tag(file_info *file);

--- a/mpck/checkframe.c
+++ b/mpck/checkframe.c
@@ -28,6 +28,7 @@
 #include "frame.h"
 #include "print.h"
 #include "id3.h"
+#include "ape.h"
 #include "crc.h"
 #include "options.h"
 #include "matrices.h"
@@ -205,7 +206,7 @@ findframe(file, frame)
 	frame_info 	* frame;
 {
 	int res;
-	char buf[6];
+	char buf[8];
 	char * ptr;
 	
 	do {
@@ -244,6 +245,17 @@ findframe(file, frame)
 				skip_id3v2_tag(file);
 			} else {
 				alienbytes(file, 3);
+			}
+        } else if (*ptr == 'A') {   /* APETAGEX -> APE tag */
+			res = cfread(++ptr, 7, file->fp);
+			if (res < 7) continue;
+			if (*ptr++ == 'P' && *ptr++ == 'E' &&
+                *ptr++ == 'T' && *ptr++ == 'A' &&
+                *ptr++ == 'G' && *ptr++ == 'E' &&
+                *ptr++ == 'X') {
+				skip_ape_tag(file);
+			} else {
+				alienbytes(file, 8);
 			}
 		} else {
 			alienbytes(file, 1);

--- a/mpck/file.c
+++ b/mpck/file.c
@@ -151,7 +151,22 @@ file_print_verbose(file)
 	printf("    %-30s%s\n", "stereo", strbool(file->stereo));
 	printf("    %-30s%d KiB\n", "size", file->length/1024);
 	printf("    %-30s%s\n", "ID3V1", strbool(file->id3&ID3V1));
+
 	printf("    %-30s%s\n", "ID3V2", strbool(file->id3&ID3V2));
+    if (file->id3 & ID3V2) {
+	    printf("        %-26s%d B\n", "size", file->id3v2_size);
+    }
+
+	printf("    %-30s%s\n", "APEV1", strbool(file->ape&APEV1));
+    if (file->ape & APEV1) {
+	    printf("        %-26s%d B\n", "size", file->apev1_size);
+    }
+    
+	printf("    %-30s%s\n", "APEV2", strbool(file->ape&APEV2));
+    if (file->ape & APEV2) {
+	    printf("        %-26s%d B\n", "size", file->apev2_size);
+    }
+
 	file_print_lastframe(file);
 }
 
@@ -306,7 +321,21 @@ file_print_xml(file)
 		if (file->vbr) printf("\t\t<vbr />\n");
 		printf("\t\t<frames>%d</frames>\n", file->frames);
 		if (file->id3 & ID3V1) printf("\t\t<id3v1 />\n");
-		if (file->id3 & ID3V2) printf("\t\t<id3v2 />\n");
+		if (file->id3 & ID3V2) {
+            printf("\t\t<id3v2>\n");
+            printf("\t\t\t<size>%d</size>\n", file->id3v2_size);
+            printf("\t\t</id3v2>\n");
+        }
+		if (file->ape & APEV1) {
+            printf("\t\t<apev1>\n");
+            printf("\t\t\t<size>%d</size>\n", file->apev1_size);
+            printf("\t\t</apev1>\n");
+        }
+		if (file->ape & APEV2) { 
+            printf("\t\t<apev2>\n");
+            printf("\t\t\t<size>%d</size>\n", file->apev2_size);
+            printf("\t\t</apev2>\n");
+        }
 		printf("\t\t<time>%d:%02d.%03d</time>\n", file->time / 60, file->time % 60, file->msec);
 		printf("\t</MPEG>\n");
 	}

--- a/mpck/file.h
+++ b/mpck/file.h
@@ -45,6 +45,10 @@ struct _file_info {
 	int alien_between;	/* junk between first and last frame	*/
 	int alien_after;	/* junk after all frames		*/
 	int id3;		/* bitwise OR of 0, ID3V1, ID3V2.	*/
+    int id3v2_size; /* total number of bytes in ID3v2 tag */
+	int ape;		/* bitwise OR of 0, APEV1, APEV2.	*/
+    int apev1_size;   /* total number of bytes in APEv1 tag */
+    int apev2_size;   /* total number of bytes in APEv2 tag */
 	int version;		/* MPEG version				*/
 	int layer;		/* layer				*/
 	int bitrate;		/* bitrate in bps			*/

--- a/mpck/mpck.h
+++ b/mpck/mpck.h
@@ -97,6 +97,9 @@
 #define ID3V1 1
 #define ID3V2 2
 
+#define APEV1 1
+#define APEV2 2
+
 #define STEREO 0
 #define JOINT 1
 #define DUAL 2


### PR DESCRIPTION
Discovered the existence of APE tags today while inspecting a few MP3s.  I'm not sure how common they are, but it was helpful to know they were there for my purposes (especially since some MP3 inspectors erroneously identified them as id3v1).  

http://wiki.hydrogenaudio.org/index.php?title=APEv2_specification
http://audacity.googlecode.com/svn/audacity-src/trunk/lib-src/taglib/taglib/ape/ape-tag-format.txt

Additionally, I needed to know the size of the id3 tags, mostly to find files where large image files where embedded as cover art.  Those values were already being computed so I added the information to the program's output so I  could access it.

Thought I'd contribute back just in case someone else finds this useful!
