### PR TITLE
set specific Windows API version so that rebar works

### DIFF
--- a/mp3checker/windows/listview.c
+++ b/mp3checker/windows/listview.c
@@ -24,9 +24,9 @@
  */
 
 
+#include "mp3checker.h"
 #include <windows.h>
 #include <commctrl.h>
-#include "mp3checker.h"
 #include "vector.h"
 #include "fileinfo.h"
 #include "resource.h"

--- a/mp3checker/windows/mp3checker.c
+++ b/mp3checker/windows/mp3checker.c
@@ -24,8 +24,8 @@
  */
 
 
-#include <windows.h>
 #include "mp3checker.h"
+#include <windows.h>
 #include "resource.h"
 #include <commctrl.h>
 #include "rebar.h"

--- a/mp3checker/windows/mp3checker.h
+++ b/mp3checker/windows/mp3checker.h
@@ -23,6 +23,9 @@
  * 
  */
 
+#define WINVER 0x0501
+#define _WIN32_WINNT 0x0501		/* fix API version, specifically so that the rebar control works*/
+
 #include "listview.h"
 #include "mpck.h"
 #include "file.h"

--- a/mp3checker/windows/rebar.c
+++ b/mp3checker/windows/rebar.c
@@ -23,9 +23,9 @@
  * 
  */
 
+#include "mp3checker.h"
 #include <windows.h>
 #include <commctrl.h>
-#include "mp3checker.h"
 #include "resource.h"
 
 static HWND hWndRebar;


### PR DESCRIPTION
Rebar wouldn't show when compiling on new Windows with new Visual
Studio.