### PR TITLE
Handle spaces in error messages consistently

### DIFF
--- a/mpck/checkarguments.c
+++ b/mpck/checkarguments.c
@@ -77,7 +77,7 @@ checkargument(filename, total, file)
 	errno_t res = 0;
 	if (extension_match(filename)) {
 		if (cisdirectory(filename) > 0) {
-			error(" skipping directory `%s'", filename);
+			error("skipping directory `%s'", filename);
 			return EISDIR;
 		}
 		if (!options_get_quiet() && !options_get_badonly() && !options_get_xmloutput()) {
@@ -121,7 +121,7 @@ wildcard_checkfile(wildcardpath, total)
 	wcplen=strlen(wildcardpath);
 	realfilename=(char*)malloc(wcplen+MAXPATH);
 	if (realfilename == NULL) {
-		error(" malloc failed while doing wildcard expansion\n");
+		error("malloc failed while doing wildcard expansion\n");
 		return FALSE;
 	}
 
@@ -135,7 +135,7 @@ wildcard_checkfile(wildcardpath, total)
 
 	hFind=FindFirstFile(wildcardpath, &FindFileData);
 	if (hFind == INVALID_HANDLE_VALUE) {
-		error(" no file found: %s", wildcardpath);
+		error("no file found: %s", wildcardpath);
 		return FALSE;
 	}
 
@@ -191,7 +191,7 @@ recursivecheck(dirname, total)
 	dirlen=strlen(dirname);
 	wildcarddir=(char *)malloc(dirlen+MAXPATH);
 	if (wildcarddir == NULL) {
-		error(" malloc failed");
+		error("malloc failed");
 		return FALSE;
 	}
 	
@@ -220,7 +220,7 @@ recursivecheck(dirname, total)
 	dirlen=strlen(dirname);
 	filename=(char *)malloc(2+dirlen+256);
 	if (filename == NULL) {
-		error(" malloc failed while doing recursion\n");
+		error("malloc failed while doing recursion\n");
 		return FALSE;
 	}
 	strcpy(filename, dirname);
@@ -229,7 +229,7 @@ recursivecheck(dirname, total)
 
 	dir=opendir(dirname);
 	if (dir == NULL) {
-		error(" error opening directory %s", dirname);
+		error("error opening directory %s", dirname);
 		return FALSE;
 	}
 

--- a/mpck/checkfile.c
+++ b/mpck/checkfile.c
@@ -127,7 +127,7 @@ static errno_t openfile(filename, file)
 	file->fp = cfopen(filename, "rb");
 	if (file->fp == NULL) {
 		errno_keep = errno;
-		error("%s: %s", filename, strerror(errno_keep));
+		fileerror(filename, strerror(errno_keep));
 		return errno_keep;
 	}
 	file->filename = filename;

--- a/mpck/checkframe.c
+++ b/mpck/checkframe.c
@@ -92,11 +92,11 @@ checkconsistency(file, frame)
 	}
 
 	if (file->version != frame->version) {
-		if (verbose) offseterror(file, " version differs from previous frame");
+		if (verbose) offseterror(file, "version differs from previous frame");
 		return FALSE;
 	}
 	if (file->layer != frame->layer) {
-		if (verbose) offseterror(file, " layer differs from previous frame");
+		if (verbose) offseterror(file, "layer differs from previous frame");
 		return FALSE;
 	}
 	return TRUE;
@@ -155,7 +155,7 @@ parseframe(file, fr, buf)
 
 	if (fr->crc16) {
 		res=cfread(buf, 2, file->fp);
-		if (!res) offseterror(file, " CRC read error");
+		if (!res) offseterror(file, "CRC read error");
 		fr->crc16=(buf[0]&0xff)<<8;
 		fr->crc16 += (buf[1]&0xff);
 	}
@@ -177,20 +177,20 @@ checkvalidity(file, frame)
 
 	/* These values are not valid */
 	if (frame->version == MPEG_VER_INVALID) {
-		if (verbose) offseterror(file, " unknown version");
+		if (verbose) offseterror(file, "unknown version");
 		return FALSE;
 	}
 	if (frame->layer == 4) {
-		if (verbose) offseterror(file, " unknown layer (1-3 allowed)");
+		if (verbose) offseterror(file, "unknown layer (1-3 allowed)");
 		return FALSE;
 	}
 	if (frame->bitrate < 8000) {
 		// FIXME this ignores the freeform bitrate
-		if (verbose) offseterror(file, " unknown bitrate");
+		if (verbose) offseterror(file, "unknown bitrate");
 		return FALSE;
 	}
 	if (frame->samplerate < 8000) {
-		if (verbose) offseterror(file, " unknown samplerate");
+		if (verbose) offseterror(file, "unknown samplerate");
 		return FALSE;
 	}
 	return TRUE;

--- a/mpck/main.c
+++ b/mpck/main.c
@@ -100,7 +100,7 @@ parse_options(argc, argv)
 			case 'e':
 				/* Only scan files with this extension */
 				if (strlen(optarg)>MAXEXT) {
-					error(" extension is too long");
+					error("extension is too long");
 					exit(ENAMETOOLONG);
 				}
 				options_set_extension(optarg);
@@ -108,7 +108,7 @@ parse_options(argc, argv)
 			case 'm':
 				maxname=atoi(optarg);
 				if (maxname<=0) {
-					error(" %s is not a valid argument to -m", optarg);
+					error("%s is not a valid argument to -m", optarg);
 					exit(EINVAL);
 				}
 				options_set_maxname(maxname);
@@ -133,10 +133,10 @@ parse_options(argc, argv)
 				options_set_xmloutput(TRUE);
 				break;
 			case '?':
-				error(" ambiguous match or an extraneous parameter");
+				error("ambiguous match or an extraneous parameter");
 				exit(EINVAL);
 			case ':':
-				error(" missing parameter");
+				error("missing parameter");
 				exit(EINVAL);
 			default:
 				exit(EINVAL);
@@ -166,7 +166,7 @@ main(argc, argv)
 
 	/* If there's no data after the flags, return an error. */
 	if (*argv == NULL) {
-		error(" no filename specified");
+		error("no filename specified");
 		print_usage();
 		exit(EINVAL);
 	}

--- a/mpck/print.c
+++ b/mpck/print.c
@@ -81,6 +81,11 @@ error(const char * format, ...) {
 
 	fprintf(stderr, "%s: %s\n", PROGNAME, buf);
 }
+
+void
+fileerror(const char * filename, const char * error) {
+	fprintf(stderr, "%s:%s: %s\n", PROGNAME, filename, error);
+}
 	
 void 
 offseterror(const file_info * f, const char * format, ...) {

--- a/mpck/print.c
+++ b/mpck/print.c
@@ -79,22 +79,7 @@ error(const char * format, ...) {
 	
 	if (len < 0) exit(EINVAL);
 
-	fprintf(stderr, "%s:%s\n", PROGNAME, buf);
-}
-
-void 
-fileerror(const file_info * f, const char * format, ...) {
-	va_list ap;  
-	char buf[1024];
-	int len;
-	
-	va_start(ap, format);
-	len = vsnprintf(buf, sizeof(buf), format, ap);
-	va_end(ap);
-	
-	if (len < 0) exit(EINVAL);
-
-	error("%s:%s", f->filename, buf);
+	fprintf(stderr, "%s: %s\n", PROGNAME, buf);
 }
 	
 void 
@@ -109,7 +94,7 @@ offseterror(const file_info * f, const char * format, ...) {
 	
 	if (len < 0) exit(EINVAL);
 
-	error("%s:%d:%s", f->filename, cftell(f->fp), buf);
+	fprintf(stderr, "%s:%s:%d: %s\n", PROGNAME, f->filename, cftell(f->fp), buf);
 }
 
 /* print something to let the user know we are scanning */

--- a/mpck/print.c
+++ b/mpck/print.c
@@ -94,7 +94,7 @@ offseterror(const file_info * f, const char * format, ...) {
 	
 	if (len < 0) exit(EINVAL);
 
-	fprintf(stderr, "%s:%s:%d: %s\n", PROGNAME, f->filename, cftell(f->fp), buf);
+	fprintf(stderr, "%s:%s:%zu: %s\n", PROGNAME, f->filename, cftell(f->fp), buf);
 }
 
 /* print something to let the user know we are scanning */

--- a/mpck/print.h
+++ b/mpck/print.h
@@ -26,6 +26,5 @@
 void print_version(void);
 void print_usage(void);
 void error(const char *format, ...);
-void fileerror(const file_info *f, const char *format, ...);
 void offseterror(const file_info *f, const char *format, ...);
 void print_scanning(const char *filename);

--- a/mpck/print.h
+++ b/mpck/print.h
@@ -26,5 +26,6 @@
 void print_version(void);
 void print_usage(void);
 void error(const char *format, ...);
+void fileerror(const char * filename, const char * error);
 void offseterror(const file_info *f, const char *format, ...);
 void print_scanning(const char *filename);


### PR DESCRIPTION
And remove fileerror, since it isn't used.