### PR TITLE
Use another debug build option to avoid error

### DIFF
--- a/vc++/mp3checker/mp3checker.dsp
+++ b/vc++/mp3checker/mp3checker.dsp
@@ -68,8 +68,8 @@ LINK32=link.exe
 # PROP Intermediate_Dir "Debug"
 # PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
-# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_MBCS" /YX /FD /GZ /c
-# ADD CPP /nologo /W3 /Gm /GX /ZI /Od /I "..\..\mpck" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_MBCS" /YX /FD /GZ /c
+# ADD BASE CPP /nologo /W3 /Gm /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_MBCS" /YX /FD /GZ /c
+# ADD CPP /nologo /W3 /Gm /GX /Zi /Od /I "..\..\mpck" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_MBCS" /YX /FD /GZ /c
 # ADD BASE MTL /nologo /D "_DEBUG" /mktyplib203 /win32
 # ADD MTL /nologo /D "_DEBUG" /mktyplib203 /win32
 # ADD BASE RSC /l 0x413 /d "_DEBUG"

--- a/vc++/mpck/mpck.dsp
+++ b/vc++/mpck/mpck.dsp
@@ -63,8 +63,8 @@ LINK32=link.exe
 # PROP Output_Dir "Debug"
 # PROP Intermediate_Dir "Debug"
 # PROP Target_Dir ""
-# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
-# ADD CPP /nologo /W3 /Gm /GX /ZI /Od /I "..\..\libgnugetopt-1.2" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
+# ADD BASE CPP /nologo /W3 /Gm /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
+# ADD CPP /nologo /W3 /Gm /GX /Zi /Od /I "..\..\libgnugetopt-1.2" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
 # ADD BASE RSC /l 0x413 /d "_DEBUG"
 # ADD RSC /l 0x413 /d "_DEBUG"
 BSC32=bscmake.exe

--- a/vc++/mpck/mpck.plg
+++ b/vc++/mpck/mpck.plg
@@ -8,7 +8,7 @@
 <h3>Command Lines</h3>
 Creating temporary file "C:\DOCUME~1\sjoerd\LOCALS~1\Temp\RSP24.tmp" with contents
 [
-/nologo /MLd /W3 /Gm /GX /ZI /Od /I "..\..\libgnugetopt-1.2" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /Fp"Debug/mpck.pch" /YX /Fo"Debug/" /Fd"Debug/" /FD /GZ /c 
+/nologo /MLd /W3 /Gm /GX /Zi /Od /I "..\..\libgnugetopt-1.2" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /Fp"Debug/mpck.pch" /YX /Fo"Debug/" /Fd"Debug/" /FD /GZ /c 
 "C:\Documents and Settings\sjoerd\Mijn documenten\checkmate.cleanup\mpck\checkarguments.c"
 "C:\Documents and Settings\sjoerd\Mijn documenten\checkmate.cleanup\mpck\checkfile.c"
 "C:\Documents and Settings\sjoerd\Mijn documenten\checkmate.cleanup\mpck\checkframe.c"


### PR DESCRIPTION
After converting to newer solution in VS, this error prevents from building:
Command line error D8016: '/ZI' and '/Gy-' command-line options are incompatible