### PR TITLE
Fix the build process

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ## Automake
 
-EXTRA_DIST = ABOUT_FIXING HISTORY mpck.1 vc++ mp3checker debian mpck-0.10.ebuild
+EXTRA_DIST = ABOUT_FIXING HISTORY mpck.1 vc++ mp3checker debian README.md
 
 SUBDIRS = libgnugetopt-1.2 mpck
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ(2.57)
 AC_INIT([checkmate], [0.20], [sjoerd-mpck@linuxonly.nl])
-AM_INIT_AUTOMAKE([checkmate], [0.20])
+AM_INIT_AUTOMAKE([foreign])
 AM_CONFIG_HEADER(config.h)
 
 AC_CONFIG_SRCDIR([mpck/main.c])


### PR DESCRIPTION
* Don't include mpck-0.10.ebuild, since we have removed this.
* Include README.md instead of README.
* Use "foreign" mode for Automake, since we no longer have a README.